### PR TITLE
Crossover browsers keyframes and percentage support

### DIFF
--- a/scoper.js
+++ b/scoper.js
@@ -11,7 +11,7 @@ function scoper(css, prefix) {
   var re = new RegExp("([^\r\n,{}]+)(,(?=[^}]*{)|\s*{)", "g");
   css = css.replace(re, function(g0, g1, g2) {
 
-    if (g1.match(/^\s*(@media|@keyframes|to|from|@font-face)/)) {
+    if (g1.match(/^\s*(@media|@.*keyframes|to|from|@font-face|1?[0-9]?[0-9])/)) {
       return g1 + g2;
     }
 


### PR DESCRIPTION
Hi!

Thanks for this amazing package.

With this PR: `@-webkit-keyframes`, `@-moz-keyframes`, `100%`, `50%`, `0%` are not modified by the script.

